### PR TITLE
[TKNECO-50] GitHub Actor vs. Repository Owner

### DIFF
--- a/inputs.sh
+++ b/inputs.sh
@@ -11,6 +11,7 @@
 # environment variables shared by default
 declare -rx GITHUB_ACTOR="${GITHUB_ACTOR:-}"
 declare -rx GITHUB_REPOSITORY="${GITHUB_REPOSITORY:-}"
+declare -rx GITHUB_REPOSITORY_OWNER="${GITHUB_REPOSITORY_OWNER:-}"
 declare -rx GITHUB_REF_NAME="${GITHUB_REF_NAME:-}"
 
 # the image tag's suffix for tekton task bundle
@@ -18,7 +19,16 @@ declare -rx INPUT_BUNDLE_TAG_SUFFIX="${INPUT_BUNDLE_TAG_SUFFIX:-}"
 # github authorization token
 declare -rx GITHUB_TOKEN="${GITHUB_TOKEN:-}"
 
-for v in GITHUB_ACTOR GITHUB_TOKEN GITHUB_REPOSITORY GITHUB_REF_NAME INPUT_BUNDLE_TAG_SUFFIX; do
+declare -ra _required_env=(
+	GITHUB_ACTOR
+	GITHUB_TOKEN
+	GITHUB_REPOSITORY
+	GITHUB_REPOSITORY_OWNER
+	GITHUB_REF_NAME
+	INPUT_BUNDLE_TAG_SUFFIX
+)
+
+for v in ${_required_env[@]}; do
 	[[ -z "${!v}" ]] &&
 		fail "'${v}' environment variable is not set!"
 done
@@ -66,17 +76,21 @@ declare -rx RENDERED_TASK_FILE="${BASE_DIR}/${TASK_FILE_NAME}"
 declare -rx LOCAL_REGISTRY="127.0.0.1:5000"
 declare -rx TARGET_REGISTRY="ghcr.io"
 
-# local and target registries hostname, followed by the path (namespace)
-declare -rx LOCAL_REGISTRY_NAMESPACE="${LOCAL_REGISTRY}/${GITHUB_ACTOR}"
-declare -rx TARGET_REGISTRY_NAMESPACE="${TARGET_REGISTRY}/${GITHUB_ACTOR}"
+# local registry namespace is the registry hostname plus the namespace (username)
+declare -rx LOCAL_REGISTRY_NAMESPACE="${LOCAL_REGISTRY}/${GITHUB_REPOSITORY_OWNER}"
+declare -rx TARGET_REGISTRY_NAMESPACE="${TARGET_REGISTRY}/${GITHUB_REPOSITORY_OWNER}"
+
+# full image name for local and target container registries
+declare -rx LOCAL_REGISTRY_IMAGE="${LOCAL_REGISTRY}/${GITHUB_REPOSITORY}"
+declare -rx TARGET_REGISTRY_IMAGE="${TARGET_REGISTRY}/${GITHUB_REPOSITORY}"
 
 # helm chart fully qualified image name, for local and remote (target) container registries
-declare -rx LOCAL_CHART_IMAGE_TAG="${LOCAL_REGISTRY_NAMESPACE}/${CHART_NAME}:${CHART_VERSION}"
-declare -rx TARGET_CHART_IMAGE_TAG="${TARGET_REGISTRY_NAMESPACE}/${CHART_NAME}:${CHART_VERSION}"
+declare -rx LOCAL_CHART_IMAGE_TAG="${LOCAL_REGISTRY_IMAGE}:${CHART_VERSION}"
+declare -rx TARGET_CHART_IMAGE_TAG="${TARGET_REGISTRY_IMAGE}:${CHART_VERSION}"
 
 # task bundle tag name, using the chart version and bundle tag suffix informed
 declare -rx BUNDLE_TAG="${CHART_VERSION}${INPUT_BUNDLE_TAG_SUFFIX}"
 
 # task bundle fully qualified image names, local and remote (target) registries
-declare -rx LOCAL_BUNDLE_IMAGE_TAG="${LOCAL_REGISTRY_NAMESPACE}/${CHART_NAME}:${BUNDLE_TAG}"
-declare -rx TARGET_BUNDLE_IMAGE_TAG="${TARGET_REGISTRY_NAMESPACE}/${CHART_NAME}:${BUNDLE_TAG}"
+declare -rx LOCAL_BUNDLE_IMAGE_TAG="${LOCAL_REGISTRY_IMAGE}:${BUNDLE_TAG}"
+declare -rx TARGET_BUNDLE_IMAGE_TAG="${TARGET_REGISTRY_IMAGE}:${BUNDLE_TAG}"

--- a/notes.sh
+++ b/notes.sh
@@ -37,7 +37,7 @@ kubectl apply -f "${release_url}/${TASK_FILE_NAME}"
 With \`tkn bundle\` you can rollout the Task from container-image, i.e:
 
 \`\`\`bash
-tkn bundle list "${TARGET_REGISTRY_NAMESPACE}/${CHART_NAME}:${BUNDLE_TAG}" task -o yaml | kubectl apply -f -
+tkn bundle list "${TARGET_BUNDLE_IMAGE_TAG}" task -o yaml | kubectl apply -f -
 \`\`\`
 
 ## Helm-Chart
@@ -53,6 +53,6 @@ helm install ${CHART_NAME} "${release_url}/${TARBALL_FILE_NAME}"
 Alternatively, you can use the Chart container image:
 
 \`\`\`bash
-helm install ${CHART_NAME} "oci://${TARGET_REGISTRY_NAMESPACE}/${CHART_NAME}" --version="${CHART_VERSION}"
+helm install ${CHART_NAME} "oci://${TARGET_REGISTRY_NAMESPACE}" --version="${CHART_VERSION}"
 \`\`\`
 EOS


### PR DESCRIPTION
Instead of using `GITHUB_ACTOR`, using `GITHUB_REPOSITORY_OWNER` to access it's container registry. The "actor" is only needed during authentication.